### PR TITLE
Fix sming.core versioning issues

### DIFF
--- a/packages/esp8266-eqt/tools/chocolateyInstall.ps1
+++ b/packages/esp8266-eqt/tools/chocolateyInstall.ps1
@@ -4,6 +4,6 @@ $url='https://github.com/SmingHub/SmingTools/releases/download/1.0/x86_64-w64-mi
 $toolBase = Get-ToolsLocation
 $eqtInstallDir = "$toolbase\esp-quick-toolchain\gnu20"
 Install-ChocolateyZipPackage "$packageName" "$url" "$eqtInstallDir"
-Install-ChocolateyEnvironmentVariable "ESP_HOME" "$eqtInstallDir"
+Install-ChocolateyEnvironmentVariable "ESP_HOME" "$eqtInstallDir" 'Machine'
 
 Update-SessionEnvironment

--- a/packages/esp8266-eqt/tools/chocolateyUninstall.ps1
+++ b/packages/esp8266-eqt/tools/chocolateyUninstall.ps1
@@ -1,6 +1,6 @@
 $packageName = 'esp8266-eqt'
 
 Uninstall-ChocolateyZipPackage "$packageName" "x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip"
-Uninstall-ChocolateyEnvironmentVariable "ESP_HOME"
+Uninstall-ChocolateyEnvironmentVariable "ESP_HOME" 'Machine'
 
 Update-SessionEnvironment

--- a/packages/sming.source/sming.core.nuspec
+++ b/packages/sming.source/sming.core.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>sming</id>
+    <id>sming.source</id>
     <version>4.1.1</version>
     <title>Sming Framework</title>
     <authors>Sming</authors>
@@ -15,11 +15,6 @@
     <tags>Sming, Arduino, ESP8266, SDK</tags>
     <dependencies>
       <dependency id="git"/>
-      <dependency id="python"/>
-      <dependency id="cmake"/>
-      <dependency id="mingw32"/>
-      <dependency id="esp8266-eqt"/>
-      <dependency id="sming.source"/>
     </dependencies>
   </metadata>
 </package>

--- a/packages/sming.source/tools/chocolateyInstall.ps1
+++ b/packages/sming.source/tools/chocolateyInstall.ps1
@@ -1,13 +1,15 @@
 
-$packageName = $env:ChocolateyPackageName
-$packageVersion = $env:ChocolateyPackageVersion 
 $url="https://github.com/SmingHub/Sming"
 $toolsRoot = Get-ToolsLocation
+$smingRoot = "$toolsRoot\Sming"
 
-chdir "$toolsRoot"
-git clone -b master $url
+if (Test-Path "$smingRoot") {
+  throw "'$smingRoot' already exists. Please remove and try again."
+}
 
-Install-ChocolateyEnvironmentVariable "SMING_HOME" "$toolsRoot\sming\Sming" 'Machine'
-Write-Debug "Set SMING_HOME to $toolsRoot\Sming\Sming"
+git clone -b master $url "$smingRoot"
+
+Install-ChocolateyEnvironmentVariable "SMING_HOME" "$smingRoot\Sming" 'Machine'
+Write-Debug "Set SMING_HOME to $smingRoot\Sming"
 
 Update-SessionEnvironment

--- a/packages/sming.source/tools/chocolateyInstall.ps1
+++ b/packages/sming.source/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+
+$packageName = $env:ChocolateyPackageName
+$packageVersion = $env:ChocolateyPackageVersion 
+$url="https://github.com/SmingHub/Sming"
+$toolsRoot = Get-ToolsLocation
+
+chdir "$toolsRoot"
+git clone -b master $url
+
+Install-ChocolateyEnvironmentVariable "SMING_HOME" "$toolsRoot\sming\Sming" 'Machine'
+Write-Debug "Set SMING_HOME to $toolsRoot\Sming\Sming"
+
+Update-SessionEnvironment

--- a/packages/sming.source/tools/chocolateyUninstall.ps1
+++ b/packages/sming.source/tools/chocolateyUninstall.ps1
@@ -1,0 +1,11 @@
+
+$toolsRoot = Get-ToolsLocation
+$smingRoot = "$toolsRoot\Sming"
+
+if (Test-Path "$smingRoot") {
+  Remove-Item "$smingRoot" -Recurse -Force -Confirm
+}
+
+Uninstall-ChocolateyEnvironmentVariable "SMING_HOME" 'Machine'
+
+Update-SessionEnvironment

--- a/packages/sming/sming.nuspec
+++ b/packages/sming/sming.nuspec
@@ -15,7 +15,7 @@
     <tags>Sming, Arduino, ESP8266, SDK</tags>
     <dependencies>
       <dependency id="git"/>
-      <dependency id="python"/>
+      <dependency id="python3" version="3.9.1"/>
       <dependency id="cmake"/>
       <dependency id="mingw32"/>
       <dependency id="esp8266-eqt"/>

--- a/packages/sming/sming.nuspec
+++ b/packages/sming/sming.nuspec
@@ -15,7 +15,7 @@
     <tags>Sming, Arduino, ESP8266, SDK</tags>
     <dependencies>
       <dependency id="git"/>
-      <dependency id="python3" version="3.9.1"/>
+      <dependency id="python3" version="[3.9.1,3.10]"/>
       <dependency id="cmake"/>
       <dependency id="mingw32"/>
       <dependency id="esp8266-eqt"/>

--- a/packages/sming/tools/chocolateyInstall.ps1
+++ b/packages/sming/tools/chocolateyInstall.ps1
@@ -1,0 +1,7 @@
+
+$python = "C:\Python39\python"
+
+Install-ChocolateyEnvironmentVariable "PYTHON" "$python" 'Machine'
+Write-Debug "Set PYTHON to $python"
+
+Update-SessionEnvironment

--- a/packages/sming/tools/chocolateyUninstall.ps1
+++ b/packages/sming/tools/chocolateyUninstall.ps1
@@ -1,0 +1,4 @@
+
+Uninstall-ChocolateyEnvironmentVariable "PYTHON" 'Machine'
+
+Update-SessionEnvironment


### PR DESCRIPTION
There's a sming.core package version 0.0.4 in the main Chocolatey repo, marked 'approved'.
This gets picked in preference to our 4.1.1 version.

This PR creates a new `sming.source` package which avoids the issue altogether.

Also set the PYTHON environment variable